### PR TITLE
Choose curl/wget flexibly as download tool

### DIFF
--- a/fetch-latest-widevine.sh
+++ b/fetch-latest-widevine.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
 
-ARCH=x64 # or ia32
-VERSION=$(curl -s https://dl.google.com/widevine-cdm/versions.txt | tail -n1)
+# Set ARCH variable
+ARCH=""
+case `uname -m` in
+	i?86)
+		ARCH="ia32"
+		;;
+	x86_64)
+		ARCH="x64"
+		;;
+esac
+[[ -z ${ARCH} ]] && echo "Architecture not supported" 1>&2 && exit 1
 
-curl -fsSL "$@" "https://dl.google.com/widevine-cdm/${VERSION}-linux-${ARCH}.zip"
+# Detect wget/curl
+DLTOOL=""
+which wget && DLTOOL="wget -O -"
+which curl && DLTOOL="curl -L"
+[[ -z ${DLTOOL} ]] && echo "No download tool found on this system" 1>&2 && exit 1
+
+# Begin download
+VERSION=$(${DLTOOL} https://dl.google.com/widevine-cdm/versions.txt | tail -n1)
+# Fix download argument for wget
+DARG=${@}
+[[ ${DLTOOL} == "wget -O -" ]] && DARG=`echo ${DARG} | sed 's/\-o /\-O /'` && DLTOOL="wget"
+${DLTOOL} ${DARG} "https://dl.google.com/widevine-cdm/${VERSION}-linux-${ARCH}.zip"


### PR DESCRIPTION
If a system has wget instead of curl, the fetch-latest-widevine.sh script can still work.

Tests were run and passed: https://github.com/bernardkkt/chromium-widevine/actions/runs/126721911

Signed-off-by: bernardkkt <kianshunkin@gmail.com>