### PR TITLE
Support widevine in Ubuntu 20.04 by supporting the Chromium snap package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Note: This is a fork of proprietary/chromium-widevine which works on Ubuntu 20.04 / 20.04.1 LTS.
+
+There is a [pull request](https://github.com/proprietary/chromium-widevine/pull/3) to get this upstream into [proprietary/chromium-widevine](https://github.com/proprietary/chromium-widevine).
+
+Only tested on the instructions for `(easiest) Install Google Chrome and use its Widevine distribution` (see below).
+
 # Installing Widevine on Chromium on GNU/Linux
 
 Or: How to get Spotify/Netflix working on Chromium in Linux

--- a/README.md
+++ b/README.md
@@ -31,38 +31,10 @@ The following script symlinks Google Chrome's Widevine library to Chromium's dir
 Paste this into your terminal:
 
 ```bash
-git clone https://github.com/proprietary/chromium-widevine.git && \
+git clone https://github.com/jarrellmark/chromium-widevine.git && \
 	cd chromium-widevine && \
 	./use-from-google-chrome.sh
 ```
-
-## (alternative) Install Widevine alone without Google Chrome
-
-Paste this into your shell:
-
-```bash
-git clone https://github.com/proprietary/chromium-widevine.git && \
-	cd chromium-widevine && \
-	./use-standalone-widevine.sh && \
-	killall -q -SIGTERM chromium-browser || \
-	killall -q -SIGTERM chromium && \
-	exec $(command -v chromium-browser || command -v chromium) ./test-widevine.html &
-```
-
-The first method using Google Chrome just copied one directory from its installation. Observe the Widevine directory in the Google Chrome distribution:
-
-```text
-/opt/google/chrome/WidevineCdm
-├── LICENSE
-├── manifest.json
-└── _platform_specific
-    └── linux_x64
-	        └── libwidevinecdm.so
-```
-
-We don't actually need the whole Google Chrome installation. We can recreate that tree in the Chromium directory (i.e., `/usr/lib/chromium`) with a standalone distribution of the Widevine shared library. Copying just `libwidevinecdm.so` into `/usr/lib/chromium` doesn't work.
-
-N.B. Disadvantage of this method: You might have to manually re-run this script whenever Chromium updates to get the latest Widevine. The first method piggybacks Google Chrome's distribution which is assumed to be up-to-date and updated by the same package manager that updates Chromium. Use that method unless you really don't want Google Chrome on your system.
 
 ## Test Widevine
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Note: This is a fork of proprietary/chromium-widevine which works on Ubuntu 20.04 / 20.04.1 LTS.
+# Note: This is a fork of proprietary/chromium-widevine that works on Ubuntu 20.04 / 20.04.1 LTS.
 
 There is a [pull request](https://github.com/proprietary/chromium-widevine/pull/3) to get this upstream into [proprietary/chromium-widevine](https://github.com/proprietary/chromium-widevine).
 

--- a/find-chromium.sh
+++ b/find-chromium.sh
@@ -21,11 +21,16 @@ if [ -d /usr/lib/chromium ]; then
 elif [ -d /usr/lib/chromium-browser ]; then
 	# Ubuntu
 	CHROMIUM_DIR=/usr/lib/chromium-browser
+elif [ -d $HOME/snap/chromium/current/.local ]; then
+	# Snap
+	mkdir -p $HOME/snap/chromium/current/.local/lib
+	CHROMIUM_DIR=$HOME/snap/chromium/current/.local/lib
 else
 	>&2 echo <<EOF
 Where is lib/ for chromium installed? Couldn't find it on the normal paths like:
 /usr/lib/chromium
 /usr/lib/chromium-browser
+$HOME/snap/chromium/current/local/lib
 
 Edit ./find-chromium.sh and set CHROMIUM_DIR to that directory.
 EOF


### PR DESCRIPTION
This change modifies the script to allow for Chromium in Ubuntu 20.04 LTS to support widevine.

Ubuntu 20.04 installs Chromium as a snap. This change identifies the snap location of Chromium's lib directory.

On my computer, there was no lib directory in `$HOME/snap/chromium/current/.local`, so this script creates one if it doesn't exist.

Note: Only tested on `(easiest) Install Google Chrome and use its Widevine distribution`